### PR TITLE
#15 & #18: Detect Existing and Rename Active Install Buttons

### DIFF
--- a/XvTSwitcherGUI/Installations/XvTInstallationList.cs
+++ b/XvTSwitcherGUI/Installations/XvTInstallationList.cs
@@ -36,7 +36,7 @@ namespace XvTSwitcherGUI.Installations
       }
     }
 
-    public bool HasBaseInstallation => BaseInstallation != null;
+    public bool HasBaseInstallation => BaseInstallation?.Filepath != string.Empty;
     public bool DoesInstallationExist(string name) => Installations.Any(o => o.Name == name);
 
     public XvTInstallationList() { }

--- a/XvTSwitcherGUI/Properties/AssemblyInfo.cs
+++ b/XvTSwitcherGUI/Properties/AssemblyInfo.cs
@@ -7,12 +7,12 @@ using System.Windows;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("XvTSwitcherGUI")]
+[assembly: AssemblyTitle("XvT Switcher")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("TheRahlForge")]
 [assembly: AssemblyProduct("XvTSwitcherGUI")]
-[assembly: AssemblyCopyright("Copyright ©  2024")]
+[assembly: AssemblyCopyright("Copyright © 2024 David Rahl")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -53,3 +53,4 @@ using System.Windows;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: NeutralResourcesLanguage("en")]

--- a/XvTSwitcherGUI/Properties/app.manifest
+++ b/XvTSwitcherGUI/Properties/app.manifest
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+      <applicationRequestMinimum>
+        <PermissionSet class="System.Security.PermissionSet" version="1" Unrestricted="true" ID="Custom" SameSite="site" />
+        <defaultAssemblyRequest permissionSetReference="Custom" />
+      </applicationRequestMinimum>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+    </application>
+  </compatibility>
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. 
+       
+       Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
+  <!--
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+  -->
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+</assembly>

--- a/XvTSwitcherGUI/Windows/MainWindow.xaml
+++ b/XvTSwitcherGUI/Windows/MainWindow.xaml
@@ -8,7 +8,8 @@
   d:DataContext="{d:DesignInstance Type=installations:XvTInstallationList}"
   mc:Ignorable="d"
   Title="XvT Switcher" Height="450" Width="800"
-  Closing="Window_Closing">
+  Closing="Window_Closing"
+  ContentRendered="Window_ContentRendered">
 
   <Grid Margin="10">
     <Grid.RowDefinitions>
@@ -21,22 +22,26 @@
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="Auto"/>
       <ColumnDefinition Width="Auto"/>
+      <ColumnDefinition Width="Auto"/>
       <ColumnDefinition Width="*"/>
       <ColumnDefinition Width="Auto"/>
     </Grid.ColumnDefinitions>
 
     <Label Content="Source Directory" />
-    <TextBox Name="SourceDirectory" Text="{Binding BaseInstallation.Filepath}" Grid.Column="1" Grid.ColumnSpan="2"/>
-    <Button Name="BrowseSourceDirectory" Grid.Column="3" Margin="0,0,0,0" Padding="8,0,8,0" Click="BrowseSourceDirectory_Click">...</Button>
-    <Button Name="CreateNewInstall" Grid.Row="1" Margin="5,5,5,5" Click="CreateNewInstall_Click">Create New Install</Button>
-    <Label Content="Select Active Install" Grid.Row="2" />
+    <TextBox Name="SourceDirectory" Text="{Binding BaseInstallation.Filepath}" Grid.Column="1" Grid.ColumnSpan="3" Margin="5,5,0,5"/>
+    <Button Name="BrowseSourceDirectory" Grid.Column="4" Margin="0,5,5,5" Padding="6,0,6,0" Click="BrowseSourceDirectory_Click">...</Button>
+    <Button Name="DetectExistingInstalls" Grid.Row="1" Margin="5,5,5,5" Click="DetectExistingInstalls_Click" Width="Auto">_Detect Existing Installs</Button>
+    <Button Name="CreateNewInstall" Grid.Row="1" Grid.Column="1" Margin="5,5,5,5" Click="CreateNewInstall_Click">_Create New Install</Button>
+    <Label Content="Select Active Install" Grid.Row="2" Margin="0,3,0,2" Height="Auto" VerticalAlignment="Center" />
     <ComboBox Name="SelectActiveInstall" Grid.Row="2" Grid.Column="1" 
               Width="Auto"
+              Margin="5,5,5,5"
               ItemsSource="{Binding Installations}" 
               DisplayMemberPath="Name" 
               SelectedValuePath="Name"
               SelectedValue="{Binding ActiveInstallation}"
               SelectionChanged="SelectActiveInstall_SelectionChanged"/>
+    <Button Name="RenameActiveInstall" Grid.Row="2" Grid.Column="2" Margin="5,5,5,5" Click="RenameActiveInstall_Click">_Rename</Button>
 
     <StackPanel>
 

--- a/XvTSwitcherGUI/Windows/NewInstall.xaml
+++ b/XvTSwitcherGUI/Windows/NewInstall.xaml
@@ -7,7 +7,8 @@
         mc:Ignorable="d"
         Title="New Install Name" 
         SizeToContent="WidthAndHeight"
-        WindowStartupLocation="CenterOwner">
+        WindowStartupLocation="CenterOwner"
+        ContentRendered="Window_ContentRendered">
   <Grid>
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto"/>
@@ -20,7 +21,7 @@
     </Grid.ColumnDefinitions>
 
     <Label Content="Name of new Install"/>
-    <TextBox Name="NewInstallName" Grid.Column="1" Grid.ColumnSpan="2" Margin="5,0,5,0"></TextBox>
+    <TextBox Name="NewInstallName" Grid.Column="1" Grid.ColumnSpan="2" Margin="5,5,5,5"></TextBox>
 
     <Button Name="NewInstallAccept" Click="NewInstallAccept_Click" Grid.Row="1" Grid.Column="1" Margin="5,5,5,5" IsDefault="True">_Accept</Button>
     <Button Name="NewInstallCancel" Click="NewInstallCancel_Click" Grid.Row="1" Grid.Column="2" Margin="5,5,5,5" IsCancel="True">_Cancel</Button>

--- a/XvTSwitcherGUI/Windows/NewInstall.xaml.cs
+++ b/XvTSwitcherGUI/Windows/NewInstall.xaml.cs
@@ -26,5 +26,10 @@ namespace XvTSwitcherGUI.Windows
 
     private void NewInstallAccept_Click(object sender, RoutedEventArgs e) => DialogResult = true;
     private void NewInstallCancel_Click(object sender, RoutedEventArgs e) => DialogResult = false;
+
+    private void Window_ContentRendered(object sender, EventArgs e)
+    {
+      NewInstallName.Focus();
+    }
   }
 }

--- a/XvTSwitcherGUI/XvTSwitcherGUI.csproj
+++ b/XvTSwitcherGUI/XvTSwitcherGUI.csproj
@@ -14,6 +14,29 @@
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <TargetCulture>en</TargetCulture>
+    <ProductName>XvTSwitcherGUI</ProductName>
+    <PublisherName>David Rahl</PublisherName>
+    <SuiteName>XvTSwitcher</SuiteName>
+    <WebPage>publish.htm</WebPage>
+    <AutorunEnabled>true</AutorunEnabled>
+    <ApplicationRevision>2</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <CreateDesktopShortcut>true</CreateDesktopShortcut>
+    <PublishWizardCompleted>true</PublishWizardCompleted>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -36,6 +59,24 @@
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>XvTSwitcherGUI.App</StartupObject>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignManifests>true</SignManifests>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ManifestCertificateThumbprint>B1EED79B285F948A4B155E9A63336E33D32DB967</ManifestCertificateThumbprint>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ManifestKeyFile>XvTSwitcherGUI_TemporaryKey.pfx</ManifestKeyFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <GenerateManifests>true</GenerateManifests>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TargetZone>LocalIntranet</TargetZone>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CopyDirectory, Version=1.0.3.0, Culture=neutral, processorArchitecture=MSIL">
@@ -108,13 +149,27 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <None Include="packages.config" />
+    <None Include="Properties\app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
+    <None Include="XvTSwitcherGUI_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include=".NETFramework,Version=v4.8">
+      <Visible>False</Visible>
+      <ProductName>Microsoft .NET Framework 4.8 %28x86 and x64%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
#15: Added a button with associated function to detect existing installations in the source directory's root folder by stripping parens and the base 'Star Wars - XvT' text. Will not override existing installations, or the base install.

#18: Added button to rename the active install. The SelectActiveInstall.SelectionChanged event is disabled during this operation to prevent actually CHANGING the installation when the ActiveInstallation is updated.